### PR TITLE
ファイル読み込みを修正

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -30,6 +30,6 @@
   </div><!-- /.footer__end -->
 
 </footer>
-<script src="assets/js/jquery-3.7.1.min.js"></script>
+<!-- <script src="assets/js/jquery-3.7.1.min.js"></script> -->
 <?php wp_footer(); ?>
 </body>

--- a/functions.php
+++ b/functions.php
@@ -1,0 +1,31 @@
+<?php
+
+function theme_enqueue_assets() {
+  // jQueryを読み込む
+  wp_enqueue_script('jquery');
+
+  // slickのスタイルシートを読み込む
+  wp_enqueue_style(
+    'slick-css', // ハンドル名
+    get_template_directory_uri() . '/assets/css/slick/slick.css', // slick.cssのパス
+    array(), // 依存関係なし
+    '1.8.0' // バージョン
+  );
+
+  wp_enqueue_style(
+      'slick-theme-css', // ハンドル名
+      get_template_directory_uri() . '/assets/css/slick/slick-theme.css', // slick-theme.cssのパス
+      array('slick-css'), // slick.cssに依存
+      '1.8.0' // バージョン
+  );
+
+  // slickのJavaScriptファイルを読み込む
+  wp_enqueue_script(
+      'slick-js', // ハンドル名
+      get_template_directory_uri() . '/assets/js/slick.js', // slick.min.jsのパス
+      array('jquery'), // jQueryに依存
+      '1.8.0', // バージョン
+      true // フッターで読み込む
+  );
+}
+add_action('wp_enqueue_scripts', 'theme_enqueue_assets');

--- a/header.php
+++ b/header.php
@@ -18,8 +18,9 @@
   <link rel="stylesheet" href="<?php echo get_template_directory_uri(); ?>/assets/css/reset.css">
   <!-- slick/CSS -->
   <link rel="stylesheet" href="<?php echo get_template_directory_uri(); ?>/assets/css/style.css">
-  <link rel="stylesheet" href="assets/css/slick/slick.css">
-  <link rel="stylesheet" href="assets/css/slick/slick-theme.css">
+  <!-- <link rel="stylesheet" href="assets/css/slick/slick.css">
+  <link rel="stylesheet" href="assets/css/slick/slick-theme.css"> -->
+  <?php wp_head(); ?>
 </head>
 
 <header id="header">
@@ -53,5 +54,4 @@
     <div class="menu">MENU</div><!-- /.menu -->
     <img class="menu-tab" src="<?php echo get_template_directory_uri(); ?>/assets/images/paspol-image/navigation-toggle@2x.png" alt="メニュー画像">
   </div><!-- /.header__inner--sp -->
-  <?php wp_head(); ?>
 </header>


### PR DESCRIPTION
【変更点】
・jQueryはWordPress標準のものを使うようにしました。
・Slickのパスが間違っていたので、変更ついでにfunctions.phpで管理できるように移動しました。
・wp_head()の場所が違ったので修正しました